### PR TITLE
Added DataSource parameter to Update-TabularCubeDataSource

### DIFF
--- a/DeployCube/DeployCube.psd1
+++ b/DeployCube/DeployCube.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DeployCube.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.2.1'
+ModuleVersion = '1.2.2'
 
 # ID used to uniquely identify this module
 GUID = 'de85c41f-a8ab-41b3-90ec-2cb7d1bc1cb3'

--- a/DeployCube/public/Update-TabularCubeDataSource.ps1
+++ b/DeployCube/public/Update-TabularCubeDataSource.ps1
@@ -33,7 +33,7 @@ function Update-TabularCubeDataSource
     .PARAMETER ImpersonationPwd
     The password of the account that will be used to connect to the SQL Server database.  Required for ImpersonationMode='ImpersonateAccount'.
 
-    .PARAMETER DataSourceName
+    .PARAMETER DataSource
     The name of the data source that will be updated.  Optional, use when there are multiple data sources in the deployed tabular cube database.
 
     .EXAMPLE
@@ -86,7 +86,7 @@ function Update-TabularCubeDataSource
         $ImpersonationPwd,
 
         [String] [Parameter(Mandatory = $false)]
-        $DataSourceName
+        $DataSource
     )
 
     # validate inputs
@@ -118,8 +118,8 @@ function Update-TabularCubeDataSource
 
     $rows = $returnXML.SelectNodes("//xmlAnalysis:return/rootNS:root/rootNS:row", $nsmgr);
 
-    If (![string]::IsNullOrEmpty($DataSourceName)) {
-        $rows = @($rows | Where-Object { $_.name -eq $DataSourceName })
+    If (![string]::IsNullOrEmpty($DataSource)) {
+        $rows = @($rows | Where-Object { $_.name -eq $DataSource })
     }
 
     if ($rows.Count -ge 1) {
@@ -169,7 +169,7 @@ function Update-TabularCubeDataSource
                  }
             }
 
-            $dataSource = [pscustomobject]@{
+            $dataSourceObject = [pscustomobject]@{
                 type = $type
                 name = $DataSourceName
                 description = $description
@@ -191,7 +191,7 @@ function Update-TabularCubeDataSource
             $ConnectionString  = Get-SqlConnectionString -SourceSqlServer $SourceSqlServer -SourceSqlDatabase $SourceSqlDatabase -ExistingConnectionString $ExistingConnectionString 
 
             if ($ImpersonationMode -eq 'ImpersonateAccount') {
-                $dataSource = [pscustomobject]@{
+                $dataSourceObject = [pscustomobject]@{
                     name = $DataSourceName
                     connectionString = $ConnectionString
                     maxConnections = $MaxConnections
@@ -200,7 +200,7 @@ function Update-TabularCubeDataSource
                     password = $ImpersonationPwd
                 }
             } else {
-                $dataSource = [pscustomobject]@{
+                $dataSourceObject = [pscustomobject]@{
                     name = $DataSourceName
                     connectionString = $ConnectionString
                     maxConnections = $MaxConnections
@@ -215,7 +215,7 @@ function Update-TabularCubeDataSource
                     database = $CubeDatabase
                     dataSource = $DataSourceName
                 }
-                dataSource = $dataSource
+                dataSource = $dataSourceObject
             }
         }
 

--- a/DeployCube/public/Update-TabularCubeDataSource.ps1
+++ b/DeployCube/public/Update-TabularCubeDataSource.ps1
@@ -34,7 +34,7 @@ function Update-TabularCubeDataSource
     The password of the account that will be used to connect to the SQL Server database.  Required for ImpersonationMode='ImpersonateAccount'.
 
     .PARAMETER DataSourceName
-    The name of the data source that will be updated.
+    The name of the data source that will be updated.  Optional, use when there are multiple data sources in the deployed tabular cube database.
 
     .EXAMPLE
     Update-TabularCubeDataSource -Server localhost -CubeDatabase MyCube -SourceSqlServer localhost -SourceSqlDatabase MyDB -ImpersonationMode ImpersonateServiceAccount;

--- a/DeployCube/public/Update-TabularCubeDataSource.ps1
+++ b/DeployCube/public/Update-TabularCubeDataSource.ps1
@@ -33,6 +33,9 @@ function Update-TabularCubeDataSource
     .PARAMETER ImpersonationPwd
     The password of the account that will be used to connect to the SQL Server database.  Required for ImpersonationMode='ImpersonateAccount'.
 
+    .PARAMETER DataSourceName
+    The name of the data source that will be updated.
+
     .EXAMPLE
     Update-TabularCubeDataSource -Server localhost -CubeDatabase MyCube -SourceSqlServer localhost -SourceSqlDatabase MyDB -ImpersonationMode ImpersonateServiceAccount;
 
@@ -80,8 +83,10 @@ function Update-TabularCubeDataSource
 
         [Alias("ImpersonationPassword")]
         [String] [Parameter(Mandatory = $false)]
-        $ImpersonationPwd
+        $ImpersonationPwd,
 
+        [String] [Parameter(Mandatory = $false)]
+        $DataSourceName
     )
 
     # validate inputs
@@ -112,6 +117,11 @@ function Update-TabularCubeDataSource
     $nsmgr.AddNamespace('rootNS', 		'urn:schemas-microsoft-com:xml-analysis:rowset');
 
     $rows = $returnXML.SelectNodes("//xmlAnalysis:return/rootNS:root/rootNS:row", $nsmgr);
+
+    If (![string]::IsNullOrEmpty($DataSourceName)) {
+        $rows = @($rows | Where-Object { $_.name -eq $DataSourceName })
+    }
+
     if ($rows.Count -ge 1) {
         [string]$DataSourceName = $rows[0].name;
         $type = $rows[0].type;

--- a/docs/Update-TabularCubeDataSource.md
+++ b/docs/Update-TabularCubeDataSource.md
@@ -15,7 +15,7 @@ Updates the tabular cube's connection to the source SQL database.
 ```
 Update-TabularCubeDataSource [-Server] <String> [-CubeDatabase] <String> [[-Credential] <PSCredential>]
  [-SourceSqlServer] <String> [-SourceSqlDatabase] <String> [-ImpersonationMode] <String>
- [[-ImpersonationAccount] <String>] [[-ImpersonationPwd] <String>] [<CommonParameters>]
+ [[-ImpersonationAccount] <String>] [[-ImpersonationPwd] <String>] [[-DataSource] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,6 +27,11 @@ Supports the newer PowerQuery style tabular cubes with CompatibilityLevel = 1400
 ### EXAMPLE 1
 ```
 Update-TabularCubeDataSource -Server localhost -CubeDatabase MyCube -SourceSqlServer localhost -SourceSqlDatabase MyDB -ImpersonationMode ImpersonateServiceAccount;
+```
+
+### EXAMPLE 2
+```
+Update-TabularCubeDataSource -Server localhost -CubeDatabase MyCube -SourceSqlServer localhost -SourceSqlDatabase MyDB -ImpersonationMode ImpersonateAccount -ImpersonationAccount "DOMAIN\user" -ImpersonationPwd "Password" -DataSource DataSource1;
 ```
 
 ## PARAMETERS
@@ -154,6 +159,22 @@ Aliases: ImpersonationPassword
 
 Required: False
 Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DataSource
+The name of the data source that will be updated. 
+Optional, use when there are multiple data sources in the deployed tabular cube database.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/test/Update-TabularCubeDataSource.Tests.ps1
+++ b/test/Update-TabularCubeDataSource.Tests.ps1
@@ -28,6 +28,9 @@ Describe "Update-TabularCubeDataSource" -Tag "Round2" {
         It "Should have ImpersonationPwd as a optional parameter" {
             (Get-Command Update-TabularCubeDataSource).Parameters['ImpersonationPwd'].Attributes.mandatory | Should -BeFalse;
         }
+        It "Should have DataSource as a optional parameter" {
+            (Get-Command Update-TabularCubeDataSource).Parameters['DataSource'].Attributes.mandatory | Should -BeFalse;
+        }
 
         It "Empty server" {
             { Update-TabularCubeDataSource -Server ""  -CubeDatabase "MyCube" -SourceSqlServer "localhost" -SourceSqlDatabase 'MyDB' -ImpersonationMode 'ImpersonateServiceAccount' } | Should -Throw;
@@ -62,12 +65,27 @@ Describe "Update-TabularCubeDataSource" -Tag "Round2" {
     }
 
     Context "Invalid inputs" {
+        It "PreTest Check Cube Exists 1200" {
+            ( Ping-SsasDatabase -Server "localhost" -CubeDatabase "CubeAtCompatibility1200" ) | Should -BeTrue;
+        }
+        It "PreTest Check Cube Exists 1500" {
+            ( Ping-SsasDatabase -Server "localhost" -CubeDatabase "CubeAtCompatibility1500" ) | Should -BeTrue;
+        }
+
         It "Invalid server" {
             { Update-TabularCubeDataSource -Server 'InvalidServer' -CubeDatabase "CubeAtCompatibility1200" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateServiceAccount'} | Should -Throw;
         }
 
         It "Valid server and invalid CubeDatabase" {
             { Update-TabularCubeDataSource -Server 'localhost' -CubeDatabase "TrashInput" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateServiceAccount'} | Should -Throw;
+        }
+
+        It "Invalid DataSource 1200" {
+            { Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1200" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\sd' -ImpersonationPwd 'OSzkzmdT' -DataSource "InvalidDataSource" } | Should -Throw;
+        }
+
+        It "Invalid DataSource 1500" {
+            { Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1500" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\yy' -ImpersonationPwd 'mypasswrd' -DataSource "InvalidDataSource" } | Should -Throw;
         }
     }
 
@@ -98,8 +116,23 @@ Describe "Update-TabularCubeDataSource" -Tag "Round2" {
 
         It "Valid inputs - UsernamePassword 1500" {
             ( Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1500" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'UsernamePassword' -ImpersonationAccount 'ea' -ImpersonationPassword 'open' )[1] | Should -BeTrue;
-        } 
-        
+        }
+
+        It "Valid inputs - ImpersonateAccount 1200 DataSource" {
+            ( Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1200" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\sd' -ImpersonationPwd 'OSzkzmdT' -DataSource "DatabaseToPublish")[1] | Should -BeTrue;
+        }
+
+        It "Valid inputs - ImpersonateAccount 1500 DataSource" {
+            ( Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1500" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\yy' -ImpersonationPwd 'mypasswrd' -DataSource "SQL/localhost;DatabaseToPublish")[1] | Should -BeTrue;
+        }
+
+        It "Valid inputs - ImpersonateAccount 1200 DataSource Empty" {
+            ( Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1200" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\sd' -ImpersonationPwd 'OSzkzmdT' -DataSource "")[1] | Should -BeTrue;
+        }
+
+        It "Valid inputs - ImpersonateAccount 1500 DataSource Empty" {
+            ( Update-TabularCubeDataSource -Server "localhost" -CubeDatabase "CubeAtCompatibility1500" -SourceSqlServer "localhost" -SourceSqlDatabase 'DatabaseToPublish' -ImpersonationMode 'ImpersonateAccount' -ImpersonationAccount 'xx\yy' -ImpersonationPwd 'mypasswrd' -DataSource "")[1] | Should -BeTrue;
+        }
     }
     
 }


### PR DESCRIPTION
- Allows updating specific data source on SSAS cube
- Use when multiple data sources are added on a SSAS cube
- DataSource parameter is optional and existing script logic is not affected when this parameter is not used
- When DataSource parameter is populated, only the data source with that name will be affected
- Updated documentation and version for DeployCube
- Resolves Issue #5 