### PR TITLE
Allow searching Microsoft.AnalysisServices.Deployment.exe in SSMS 20

### DIFF
--- a/DeployCube/DeployCube.psd1
+++ b/DeployCube/DeployCube.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DeployCube.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.2.4'
+ModuleVersion = '1.2.5'
 
 # ID used to uniquely identify this module
 GUID = 'de85c41f-a8ab-41b3-90ec-2cb7d1bc1cb3'

--- a/DeployCube/public/Get-AnalysisServicesDeploymentExePath.ps1
+++ b/DeployCube/public/Get-AnalysisServicesDeploymentExePath.ps1
@@ -51,7 +51,7 @@ function Get-AnalysisServicesDeploymentExePath {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('16', '15', '14', '13', '12', '11')]
+        [ValidateSet('20', '16', '15', '14', '13', '12', '11')]
         [string]$Version
     )
 

--- a/DeployCube/public/Get-AnalysisServicesDeploymentExePath.ps1
+++ b/DeployCube/public/Get-AnalysisServicesDeploymentExePath.ps1
@@ -15,7 +15,7 @@ function Get-AnalysisServicesDeploymentExePath {
 
     .PARAMETER Version
     The version of Microsoft.AnalysisServices.Deployment.exe to find.
-    Valid values for -Version are: ('16', '15', '14', '13', '12', '11') which translate as follows:
+    Valid values for -Version are: ('20', '16', '15', '14', '13', '12', '11') which translate as follows:
     
     * 16: SQL Server 2022
     * 15: SQL Server 2019

--- a/DeployCube/public/Publish-Cube.ps1
+++ b/DeployCube/public/Publish-Cube.ps1
@@ -100,7 +100,7 @@ function Publish-Cube {
         $CubeDatabase,
 
         [String] [Parameter(Mandatory = $false)]
-        [ValidateSet('16', '15', '14', '13', '12', '11', 'latest')]
+        [ValidateSet('20', '16', '15', '14', '13', '12', '11', 'latest')]
         $PreferredVersion = 'latest',
 
         [String] [Parameter(Mandatory = $false)]

--- a/DeployCube/public/Publish-Cube.ps1
+++ b/DeployCube/public/Publish-Cube.ps1
@@ -18,7 +18,7 @@ function Publish-Cube {
 
     .PARAMETER PreferredVersion
     Defines the preferred version of Microsoft.AnalysisServices.Deployment.exe you wish to use.  Use 'latest' for the latest version, or do not provide the parameter as the default is 'latest'.
-    Valid values for -PreferredVersion are: ('16', '15', '14', '13', '12', '11') which translate as follows:
+    Valid values for -PreferredVersion are: ('20', '16', '15', '14', '13', '12', '11') which translate as follows:
     * latest: Latest SQL Server version found on agent
     * 16: SQL Server 2022
     * 15: SQL Server 2019

--- a/DeployCube/public/Select-AnalysisServicesDeploymentExeVersion.ps1
+++ b/DeployCube/public/Select-AnalysisServicesDeploymentExeVersion.ps1
@@ -8,7 +8,7 @@ function Select-AnalysisServicesDeploymentExeVersion {
 
     .PARAMETER PreferredVersion
     The preferred version of Microsoft.AnalysisServices.Deployment.exe to attempt to find.
-    Valid values for -PreferredVersion are: ('16', '15', '14', '13', '12', '11', 'latest') which translate as follows:
+    Valid values for -PreferredVersion are: ('20', '16', '15', '14', '13', '12', '11', 'latest') which translate as follows:
     
     * latest: Latest SQL Server version found on agent
     * 16: SQL Server 2022

--- a/DeployCube/public/Select-AnalysisServicesDeploymentExeVersion.ps1
+++ b/DeployCube/public/Select-AnalysisServicesDeploymentExeVersion.ps1
@@ -44,14 +44,14 @@ function Select-AnalysisServicesDeploymentExeVersion {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet('16', '15', '14', '13', '12', '11', 'latest')]
+        [ValidateSet('20', '16', '15', '14', '13', '12', '11', 'latest')]
         [string] $PreferredVersion
     )
 
     try {
         [string]$ExeName = "Microsoft.AnalysisServices.Deployment.exe";
         $specificVersion = $PreferredVersion -and $PreferredVersion -ne 'latest'
-        $versions = '16', '15', '14', '13', '12', '11' | Where-Object { $_ -ne $PreferredVersion }
+        $versions = '20', '16', '15', '14', '13', '12', '11' | Where-Object { $_ -ne $PreferredVersion }
 
         # Look for a specific version of Microsoft SQL Server SSAS deployment tool
         if ($specificVersion) {

--- a/docs/Get-AnalysisServicesDeploymentExePath.md
+++ b/docs/Get-AnalysisServicesDeploymentExePath.md
@@ -46,7 +46,7 @@ Returns the SQL Server 2017 version of Microsoft.AnalysisServices.Deployment.exe
 
 ### -Version
 The version of Microsoft.AnalysisServices.Deployment.exe to find.
-Valid values for -Version are: ('16', '15', '14', '13', '12', '11') which translate as follows:
+Valid values for -Version are: ('20', '16', '15', '14', '13', '12', '11') which translate as follows:
 
 * 16: SQL Server 2022
 * 15: SQL Server 2019

--- a/docs/Publish-Cube.md
+++ b/docs/Publish-Cube.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ### -PreferredVersion
 Defines the preferred version of Microsoft.AnalysisServices.Deployment.exe you wish to use. 
 Use 'latest' for the latest version, or do not provide the parameter as the default is 'latest'.
-Valid values for -PreferredVersion are: ('16', '15', '14', '13', '12', '11') which translate as follows:
+Valid values for -PreferredVersion are: ('20', '16', '15', '14', '13', '12', '11') which translate as follows:
 * latest: Latest SQL Server version found on agent
 * 16: SQL Server 2022
 * 15: SQL Server 2019

--- a/docs/Select-AnalysisServicesDeploymentExeVersion.md
+++ b/docs/Select-AnalysisServicesDeploymentExeVersion.md
@@ -39,7 +39,7 @@ Returns the SQL Server 2017 version of Microsoft.AnalysisServices.Deployment.exe
 
 ### -PreferredVersion
 The preferred version of Microsoft.AnalysisServices.Deployment.exe to attempt to find.
-Valid values for -PreferredVersion are: ('16', '15', '14', '13', '12', '11', 'latest') which translate as follows:
+Valid values for -PreferredVersion are: ('20', '16', '15', '14', '13', '12', '11', 'latest') which translate as follows:
 
 * latest: Latest SQL Server version found on agent
 * 16: SQL Server 2022


### PR DESCRIPTION
Added the version number to allow for searching SSMS 20's install location for the ``Microsoft.AnalysisServices.Deployment.exe``.
Let me know if I forgot it somewhere.

This change doesn't include the parameter explanation in any of the scripts or the xml file yet, as it doesn't technically link back to a SQL Server version but rather an SSMS version. Also let me know if I misunderstood your documentation here.

This PR resolves #13
